### PR TITLE
Adding a fix to avoid infinite loop at last row of the query result

### DIFF
--- a/exporter/mysql_query.py
+++ b/exporter/mysql_query.py
@@ -57,6 +57,12 @@ class MysqlDumpQueryToTSV(object):
                 converted_row = [self._normalize_value(v) for v in row]
                 writer.writerow(converted_row)
 
+            # Custom Proversity fix to avoid infinite loop at last row of the query results.
+            # If less than MAX_FETCH_SIZE rows were fetched in this loop then is safe to
+            # assume there won't be anymore results and we can exit the cycle.
+            if len(rows) < MAX_FETCH_SIZE:
+                break
+
     def _normalize_value(self, value):
         if value is None: value='NULL'
         return unicode(value).encode('utf-8').replace('\\', '\\\\').replace('\r', '\\r').replace('\t','\\t').replace('\n', '\\n')


### PR DESCRIPTION
For some reason the exporter was getting into an infinite loop when processing the rows from the courseware_studentmodule table, always returning the last row of the result in every iteration.

This PR adds a quick fix to avoid this by forcing the loop to finish if all rows were processed.